### PR TITLE
feat: Add Claude skills and wire into installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.claude/settings.json

--- a/claude-skills/commit/SKILL.md
+++ b/claude-skills/commit/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: commit
+description: Stage and commit changes using project conventions
+disable-model-invocation: true
+---
+
+Stage and commit changes following these conventions:
+
+## Commit message format
+
+```
+type: Subject line (50 chars or less)
+
+- Body line one (72 chars or less)
+- Body line two (72 chars or less)
+```
+
+- **Types:** `feat`, `fix`, `chore`, `style`, `refactor`, `test`
+- **No scopes** — never use `type(scope):` format
+- **Sentence case** — capitalize the first word only
+- **Imperative mood** — "Add", "Fix", "Update", not "Added", "Fixes", "Updated"
+- **No trailing period**
+- Use **backticks** for specific file or script names (e.g., `fix: Update \`prepare-commit-msg\` hook`)
+- **Subject line must be 50 characters or less** — GitHub truncates beyond this
+- **Body lines must be 72 characters or less** — if a point needs more, wrap it onto the next line, but only the first line of each point gets a hyphen prefix
+
+## Commit body
+
+**Always write a body. The body must explain *why*, not *what*.** Git already shows exactly what changed — a reviewer can run `git diff` and see every line. What they cannot see is your reasoning: why this approach, why now, what problem it solves, what you considered and rejected.
+
+Ask yourself: *"What would I want to know about this change if I were reading it six months from now with no context?"* Write that.
+
+Bad body (describes what, git already shows this):
+```
+- Added error handling to fetchUser
+- Updated return type to include null
+```
+
+Good body (explains why):
+```
+- fetchUser was silently swallowing 404s and returning an empty object,
+  causing downstream components to render as if the user existed
+- Returning null on 404 lets callers handle the missing-user case explicitly
+```
+
+## Commit strategy
+
+**Commit by idea, not by file.** Group changes by logical unit — a feature, a bug fix, a refactor — so each commit can be reverted independently without breaking unrelated work.
+
+**Order commits so the build passes at every step.** If changes are being committed from unstaged files, sequence them so that checking out any individual commit leaves the project in a working, buildable state. Never commit a dependency before the thing it depends on.
+
+## Steps
+
+1. Run `git status` and `git diff` to understand all pending changes
+2. Group the changes into logical commits — one idea per commit
+3. Plan the commit order so each one leaves the build passing
+4. For each commit:
+   - Stage only the files relevant to that idea with `git add`
+   - Write a message following the format above
+   - Commit with `git commit -m "<message>"`
+5. Repeat until all changes are committed

--- a/claude-skills/create-pr/SKILL.md
+++ b/claude-skills/create-pr/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: create-pr
+description: Open a pull request for the current branch using the repo's PR template
+disable-model-invocation: true
+---
+
+Open a pull request for the current branch.
+
+## Steps
+
+1. **Check for a PR template** by looking for:
+   - `.github/pull_request_template.md`
+   - `.github/PULL_REQUEST_TEMPLATE.md`
+   - `.github/PULL_REQUEST_TEMPLATE/*.md` (multiple templates)
+
+2. **Determine the PR title** from the branch's commits:
+   - If the branch has a single commit, derive the title from its subject line
+   - If the branch has multiple commits, write a title that summarizes the overall change
+   - Use **Title Case** — no commit type prefix (no `feat:`, `chore:`, etc.)
+   - Be succinct: describe what the PR does, not how it does it
+
+3. **Fill out the PR body:**
+   - If a template exists, **fill out every section in full** — do not delete sections, leave placeholders, or write "N/A" without explanation. Read the commits and diff to answer each section with real content.
+   - If no template exists, write a body that covers: what changed, why, and how to verify it.
+
+4. **Open the PR** with `gh pr create`:
+
+   ```
+   gh pr create --title "<title>" --body "<body>"
+   ```
+
+5. **Output the PR URL** so the user can review it.
+
+## Rules
+
+- **Never skip template sections.** If a section asks for a test plan, write one based on what actually changed. If it asks for context, provide it from the commits.
+- The body should be written for a reviewer who has no prior context — assume they are coming in cold.

--- a/claude-skills/curate-commits-for-main/SKILL.md
+++ b/claude-skills/curate-commits-for-main/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: curate-commits-for-main
+description: Collapse commits on the current branch into clean, atomic commits ready to land on main
+disable-model-invocation: true
+---
+
+Collapse the commit history of the current branch into a small set of clean, stable, atomic commits that represent complete ideas — not the step-by-step record of how the work was done.
+
+## Philosophy
+
+A PR review values narrative: many commits that build context incrementally. Main's history values clarity: a compact record where each commit represents one complete, self-contained idea that can be understood, bisected, or reverted in isolation.
+
+The bar here is higher than for PR curation. If multiple commits all belong to the same feature, fix, or theme, they become one commit. Dependency updates across multiple packages become one commit. Housekeeping and chore work gets consolidated. When in doubt, squash.
+
+**The only reason to keep two commits separate is if they represent genuinely distinct, independently revertable ideas.**
+
+## Steps
+
+### 1. Survey the branch
+
+```
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+Group every commit by idea. Common groupings:
+- All commits for a single feature or fix → one commit
+- All dependency updates → one commit
+- All chore/housekeeping (config, docs, style) → one commit, unless unrelated
+
+### 2. Present the consolidation plan
+
+**Do not begin the rebase yet.** Present a plan to the user first and wait for explicit approval.
+
+The plan must list every commit currently on the branch, grouped by the proposed final commit, in the proposed final order:
+
+| # | SHAs | Action | Current messages | New message | Notes |
+|---|------|--------|------------------|-------------|-------|
+| 1 | `abc1234` | pick | chore: Update deps | — | Keeping as-is; one dep update |
+| 2 | `def5678` + `ghi9012` + `jkl3456` | squash | feat: Add login page / feat: Add form validation / fix: Fix form submit | feat: Add login page with form validation | Three commits, one idea |
+| 3 | `mno7890` | pick | fix: Fix unrelated bug | — | Distinct and independently revertable |
+
+- List **every** current SHA — none may be silently omitted.
+- Use `—` in the "New message" column when the message is unchanged.
+- For drops, add a row with action `drop` and explain why.
+- End with: **Proceed with this plan?**
+
+**Never drop a commit without listing it explicitly in the plan and explaining why.** Always wait for the user to approve.
+
+### 3. Execute after approval
+
+Once the user approves, run:
+
+```
+git rebase -i main
+```
+
+Apply the approved operations. When resolving merge conflicts during rebase, ask: *"How would I have made this change had the preceding commits already been in place?"*
+
+**When combining commits with squash or fixup:** always place the earlier commit first. If a later commit touching file A needs to come before an earlier commit also touching file A, the patch won't apply cleanly.
+
+Example: commits 1 (file A), 2 (file B), 3 (file A) — to fold 3 into 1, order them `1, 3, 2` (fixup), not `3, 1, 2`.
+
+### 4. Write commit messages that explain *why*
+
+Use the Conventional Commits format:
+
+```
+<type>: <subject> (50 chars or less)
+
+<body — explain why, not what. Git already shows what changed.>
+
+<footer — ticket references, breaking change notices>
+```
+
+- **Types:** `feat`, `fix`, `refactor`, `chore`, `docs`, `style`, `test`
+- **No scopes** — never use `type(scope):` format (e.g. `chore(deps):` is wrong; use `chore:`)
+- **Subject:** imperative mood, sentence case, no trailing period
+- **Body:** the *why* and the *context* — what would be valuable to know when reading this commit 6 months from now?
+
+When squashing multiple commits into one, write a unified message that captures the full scope of the idea — do not just concatenate the original messages.
+
+### 5. Push the rewritten history
+
+**Do not push unless the user explicitly asks you to.** When asked, use:
+
+```
+git push --force-with-lease --force-if-includes
+```
+
+**Never use `--force` alone.** `--force-with-lease --force-if-includes` is the only acceptable option: it rejects the push if someone else has pushed commits to your branch that you don't have locally, preventing you from silently overwriting their work.
+
+### 6. Summarize the result
+
+After curating, output a summary of the final commit list (one line per commit) and a brief explanation of what was consolidated and why the resulting history is the right shape for main.

--- a/claude-skills/curate-commits/SKILL.md
+++ b/claude-skills/curate-commits/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: curate-commits
+description: Reorganize commits on the current branch into a reviewer-friendly narrative using interactive rebase
+disable-model-invocation: true
+---
+
+Curate the commit history of the current branch so it reads like a story for a reviewer — not a chronological record of how the work was done, but a logical narrative that guides the reviewer through the thought process and evolution of the change.
+
+## Philosophy
+
+A reviewer cannot fully understand a large PR by jumping straight to the end and viewing all file changes at once. They need to be onboarded through the commits in an order that progressively builds context. The commit history should make the thought process behind the PR immediately clear.
+
+The order commits were *made* is rarely the order they should be *reviewed*. Like an essay — readers don't see it in the order it was written. Reorder, reshape, and rename commits so the history serves the reader.
+
+## Steps
+
+### 1. Survey the current branch
+
+```
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+Review all commits on the branch relative to main. Identify:
+- Commits that cover multiple ideas and should be split
+- Commits that cover the same idea and should be squashed or fixed up
+- Commits that are out of logical order
+- WIP, temp, or debug commits that are candidates for dropping
+- Commits with poor messages that should be reworded
+- Unrelated housekeeping (dep updates, chore, docs) that should be grouped and repositioned
+
+### 2. Present the curation plan
+
+**Do not begin the interactive rebase yet.** Present a plan to the user first and wait for explicit approval before proceeding.
+
+The plan must list every commit currently on the branch and the proposed action for each one, in the proposed final order. Present it as a table:
+
+| # | SHA | Action | Current message | New message | Notes |
+|---|-----|--------|-----------------|-------------|-------|
+| 1 | `abc1234` | pick | chore: Update dependencies | — | Moving to front; foundation for the rest |
+| 2 | `def5678` | reword | feat: Add data service | feat: Add UserDataService for fetching profile data | Subject was too vague |
+| 3 | `ghi9012` + `jkl3456` | fixup | feat: Wire data service into profile page | — | Folding in "forgot to stage this" commit |
+| 4 | `mno7890` | edit (split) | feat: Add profile page and fix unrelated bug | feat: Add profile page / fix: ... | Two ideas in one commit |
+
+- Use `—` in the "New message" column when the message is unchanged.
+- For drops, add a row with action `drop` and explain in the Notes column.
+- End with: **Proceed with this plan?**
+
+**Never drop a commit without listing it explicitly in the plan and explaining why.** Always wait for the user to approve before executing any drops.
+
+### 3. Execute after approval
+
+Once the user approves the plan, run:
+
+```
+git rebase -i main
+```
+
+Apply the approved operations. When resolving merge conflicts during rebase, ask: *"How would I have made this change had the preceding commits already been in place?"*
+
+### 4. Design the narrative order
+
+Plan the commit sequence that best onboards a reviewer. A good ordering usually follows this pattern:
+
+1. **Foundation first** — chores, dependency updates, infrastructure changes, or scaffolding that the rest of the work builds on
+2. **Core logic** — the primary feature or fix in a logical build-up, where each commit makes sense given the previous one
+3. **Integration** — wiring things together, consuming the new code
+4. **Polish** — tests, documentation, style, cleanup
+
+Ask: *"If a reviewer read these commits one by one, would each commit make sense given what came before it?"* If not, reorder.
+
+Ask: *"If a reviewer checked out any individual commit, would the code make sense?"* If not, a commit may need to be split or reordered.
+
+### 5. Available operations
+
+| Operation | When to use |
+|-----------|-------------|
+| **reorder** (pick) | Related commits are not grouped together; commits that depend on each other are out of order |
+| **squash (s)** | Two commits express the same idea; preserve both commit messages |
+| **fixup (f)** | A commit is a trivial addendum to the previous one (forgot a file, minor fix); discard the extra message. Also use fixup when a later commit only tunes or adjusts something introduced by an earlier commit (e.g. changing a delay value, expanding a pool size, tweaking a parameter) — these belong in the original commit even if they aren't adjacent |
+
+**When combining commits with fixup or squash:** always place the earlier commit first. Reordering so that a later commit precedes the one it's being folded into causes merge conflicts, because git applies patches in sequence — if a later commit touching file A comes before the earlier commit that also touched file A, the patch won't apply cleanly.
+
+Example: commits 1 (file A), 2 (file B), 3 (file A) — to fold 3 into 1, order them `1, 3, 2` (fixup), not `3, 1, 2`.
+| **edit (e)** | A single commit encompasses too many ideas and needs to be split |
+| **reword (r)** | The message is vague, has a typo, or lacks context |
+| **drop (d)** | WIP commits, debug/temp commits, or accidental commits — **requires explicit user approval** |
+
+### 6. Write commit messages that explain *why*
+
+Use the Conventional Commits format:
+
+```
+<type>: <subject> (50 chars or less)
+
+<body — explain why, not what. Git already shows what changed.>
+
+<footer — ticket references, breaking change notices>
+```
+
+- **Types:** `feat`, `fix`, `refactor`, `chore`, `docs`, `style`, `test`
+- **No scopes** — never use `type(scope):` format (e.g. `chore(deps):` is wrong; use `chore:`)
+- **Subject:** imperative mood, sentence case, no trailing period
+- **Body:** the *why* and the *context* — what would be valuable to know when reading this commit 6 months from now? What problem does this solve? What was the reasoning behind this approach?
+
+### 7. Push the rewritten history
+
+**Do not push unless the user explicitly asks you to.** When asked, use:
+
+```
+git push --force-with-lease --force-if-includes
+```
+
+**Never use `--force` alone.** `--force-with-lease --force-if-includes` is the only acceptable option: it rejects the push if someone else has pushed commits to your branch that you don't have locally, preventing you from silently overwriting their work.
+
+### 8. Summarize the result
+
+After curating, output a summary of the final commit list (one line per commit) and a brief explanation of what was changed and why the resulting order best serves a reviewer.

--- a/claude-skills/dependabot-rebase/SKILL.md
+++ b/claude-skills/dependabot-rebase/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: dependabot-rebase
+description: Trigger a rebase on all open Dependabot pull requests
+disable-model-invocation: true
+---
+
+Trigger a rebase on all open Dependabot pull requests by posting a comment.
+
+## Steps
+
+1. **Find open Dependabot PRs** using:
+   ```
+   gh pr list --author "app/dependabot" --state open --json number,title
+   ```
+   If there are none, report that and stop.
+
+2. **Post a rebase comment on every PR** without pausing or producing any output between them. Commenting is fast — outputting status after each one takes longer than just firing them all and reporting at the end:
+   ```
+   gh pr comment <number> --body "@dependabot rebase"
+   ```
+
+3. **Output a consolidated checklist** after all comments have been posted:
+   ```
+   - [x] #<number>: <title>
+   - [x] #<number>: <title>
+   ...
+   ```
+   Mark every PR that was successfully commented on as `[x]`. If any comment failed, mark it `[ ]` and note the error.

--- a/claude-skills/update-deps/SKILL.md
+++ b/claude-skills/update-deps/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: update-deps
+description: Update dependencies for the project in the current working directory
+disable-model-invocation: true
+---
+
+Update dependencies for the project in the current working directory based on open Dependabot pull requests. Dependencies are applied in batches of 3 and tested together as a fast path — if the batch passes, move on. If it fails, reset the batch and fall back to one at a time to isolate the culprit. Each dependency ends up as its own commit so any single update can be reverted without affecting the others.
+
+## Steps
+
+1. **Prepare the local repository:**
+   - Pull the latest main branch: `git checkout main && git pull`
+   - Prune remote-tracking references and delete local branches already merged into main:
+     ```
+     git fetch --prune
+     git branch --merged main | grep -v '^\* \|^  main$' | xargs -r git branch -d
+     ```
+   - Create and check out a new branch for this work:
+     ```
+     git checkout -b chore--update-dependencies-<YYYY-MM-DD>
+     ```
+     where `<YYYY-MM-DD>` is today's date (e.g. `chore--update-dependencies-2026-02-28`).
+
+2. **Find open Dependabot PRs** using `gh pr list --author "app/dependabot" --state open --json number,title,headRefName`. If there are none, report that and stop.
+
+2. **Extract the packages to update** from the PR titles. Dependabot PR titles follow patterns like:
+   - `Bump <package> from <old> to <new>`
+   - `Bump <package> and <package> from <old> to <new>`
+   - `Update <package> requirement from <old> to <new>`
+
+3. **Present a confirmation checklist** listing every package that will be updated, showing the old and new version for each:
+   ```
+   The following dependencies will be updated in batches of 3:
+
+   - [ ] <package>: <old-version> → <new-version>  (#<pr-number>)
+   - [ ] <package>: <old-version> → <new-version>  (#<pr-number>)
+   ...
+
+   Proceed with updates? (yes/no)
+   ```
+   **Stop if the user says no.**
+
+   When reprinting the checklist during updates, mark the current batch with a `→` arrow so it's clear which 3 are actively being worked on:
+   ```
+   - [x] <package>: <old> → <new>  (#<pr-number>)   ✓ done
+   - [ ] <package>: <old> → <new>  (#<pr-number>)   ← current batch
+   - [ ] <package>: <old> → <new>  (#<pr-number>)   ← current batch
+   - [ ] <package>: <old> → <new>  (#<pr-number>)   ← current batch
+   - [ ] <package>: <old> → <new>  (#<pr-number>)
+   ...
+   ```
+
+4. **Detect the package manager** by checking for lockfiles/config files:
+   - `package-lock.json` → npm
+   - `yarn.lock` → yarn
+   - `pnpm-lock.yaml` → pnpm
+   - `Pipfile` or `Pipfile.lock` → pipenv
+   - `requirements.txt` → pip
+   - `go.mod` → go
+   - `Gemfile` → bundler
+
+5. **Process dependencies in batches of 3**, using a fast path with a one-at-a-time fallback:
+
+   ### Fast path (batch of 3)
+
+   For each batch of up to 3 PRs:
+
+   a. **Cherry-pick all PRs in the batch**, one after the other without testing between them:
+      ```
+      git fetch origin <headRefName>
+      git cherry-pick origin/<headRefName>
+      ```
+      For each cherry-pick, if there are merge conflicts resolve them before continuing:
+      - **`package.json` conflict** — resolve manually, keeping the new version from the Dependabot branch
+      - **Lockfile conflict** (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`) — unstage and regenerate:
+        - npm: `git checkout HEAD -- package-lock.json && npm install --package-lock-only`
+        - yarn: `git checkout HEAD -- yarn.lock && yarn install --frozen-lockfile=false`
+        - pnpm: `git checkout HEAD -- pnpm-lock.yaml && pnpm install --lockfile-only`
+      - Stage all resolved files and run `git cherry-pick --continue`
+
+   b. **Verify the batch with a clean install and full check:**
+      1. Sync the lockfile: `npm install --package-lock-only` — `npm ci` requires `package.json` and `package-lock.json` to be in sync
+      2. Clean install: `rm -rf node_modules && npm ci`
+      3. Run the application or build to confirm it starts
+      4. Run the test suite
+      5. Run the linter
+
+   c. **If the batch passes:** check off all items in the batch with `[x]`, reprint the full checklist showing their completed status and highlighting the next batch with `→`, then move on.
+
+   d. **If the batch fails:** reset all commits in the batch:
+      ```
+      git reset --hard HEAD~<number of commits in batch>
+      ```
+      Then fall back to the **one-at-a-time path** (below) for each PR in this batch individually.
+
+   ### One-at-a-time fallback
+
+   Apply each PR individually, running the full verification after each one:
+
+   a. Cherry-pick and resolve conflicts (same as fast path step a above).
+
+   b. **Verify** (same clean install + full check as fast path step b above).
+
+   c. **If verification passes:**
+      - If any additional files were modified to make the update work (e.g. fixing a changed API, updating a config), amend them into the cherry-pick commit:
+        ```
+        git add <modified-files>
+        git commit --amend --no-edit
+        ```
+        Never create a separate follow-up commit — a single revert must undo everything.
+      - Check off the item in the checklist with `[x]` and continue.
+
+   d. **If verification fails**, first check whether this is a **major version bump** (major version number changed, e.g. `1.4.2 → 2.0.0`):
+
+      - **Major version bump:** do not attempt debugging. Immediately run `git reset --hard HEAD~1` and ask:
+        > "`<package>` was bumped from `<old>` to `<new>` (major version). Major bumps often include breaking changes that require migration work. Would you like to skip this one?"
+        Check off as skipped with a note if they confirm, then continue.
+
+      - **Minor or patch bump:** pause and ask:
+        > "`<package>` update caused a failure in `<step>`. Would you like me to try to fix the issue, or undo and move on?"
+        - If fix: attempt to resolve, then re-run the full check. **Spend no more than 3 minutes debugging.** If unresolved, ask: "I wasn't able to fix this within 3 minutes. Should I keep trying or would you like to take over?"
+        - If skip: run `git reset --hard HEAD~1`, check off as skipped with a note, and continue.
+
+   **Do not comment on or close the Dependabot PR.** Leave it untouched until the work is merged.
+
+6. **Ask the user** if they would like to open a pull request for these changes. If yes, use the `create-pr` skill. The PR title must be **"Dependency Updates"** (always, regardless of what was updated). The body should include:
+   - The full list of dependency updates (package name, old version → new version, Dependabot PR reference)
+   - Any other commits on the branch that are unrelated to dependency updates, listed separately so reviewers are aware of them
+
+7. **Summarize** what was updated and, if a PR was opened, link to it.

--- a/install.zsh
+++ b/install.zsh
@@ -110,6 +110,16 @@ install_nedryland_greeting() {
   fi
 }
 
+install_claude_skills() {
+  claude_skills_source="$install_current_directory/claude-skills"
+  claude_skills_target="$HOME/.claude/skills"
+  mkdir -p "$HOME/.claude"
+  if [ ! -L "$claude_skills_target" ]
+  then
+    ln -s "$claude_skills_source" "$claude_skills_target"
+  fi
+}
+
 install_gh_cli() {
   if ! command_does_exist gh
   then
@@ -144,11 +154,13 @@ nedryland_init() {
   install_custom_go_path
   install_nedryland_greeting
   install_gh_cli
+  install_claude_skills
 }
 
 nedryland_update() {
   prompt_user_for_update "git config" && install_git_config
   prompt_user_for_update "git hooks" && install_git_hooks
+  prompt_user_for_update "Claude skills" && install_claude_skills
 }
 
 # Check if we need to do an initial install of Nedryland

--- a/zshell/zshell.aliases.zsh
+++ b/zshell/zshell.aliases.zsh
@@ -3,7 +3,7 @@
 . "$(dirname "$0")/zshell.nedryland.zsh"
 . "$(dirname "$0")/zshell.temp-directory.zsh"
 
-alias nedryland="nedryland_reload_show"
+alias nedryland="nedryland_resource_and_reload_show"
 alias nedryland_loaded="nedryland_loaded_show"
 alias tempdir="nedryland_create_temp_directory"
 alias persistdir="nedryland_persist_temp_directory"

--- a/zshell/zshell.aliases.zsh
+++ b/zshell/zshell.aliases.zsh
@@ -3,8 +3,8 @@
 . "$(dirname "$0")/zshell.nedryland.zsh"
 . "$(dirname "$0")/zshell.temp-directory.zsh"
 
-alias nedryland="nedryland_message_show_large"
-alias nedryland_loaded="nedryland_message_show_auto"
+alias nedryland="nedryland_reload_show"
+alias nedryland_loaded="nedryland_loaded_show"
 alias tempdir="nedryland_create_temp_directory"
 alias persistdir="nedryland_persist_temp_directory"
 alias vsc="code . && exit"

--- a/zshell/zshell.aliases.zsh
+++ b/zshell/zshell.aliases.zsh
@@ -4,7 +4,7 @@
 . "$(dirname "$0")/zshell.temp-directory.zsh"
 
 alias nedryland="nedryland_message_show_large"
-alias nedryland_loaded="nedryland_message_show_small"
+alias nedryland_loaded="nedryland_message_show_auto"
 alias tempdir="nedryland_create_temp_directory"
 alias persistdir="nedryland_persist_temp_directory"
 alias vsc="code . && exit"

--- a/zshell/zshell.nedryland.zsh
+++ b/zshell/zshell.nedryland.zsh
@@ -330,6 +330,10 @@ nedryland_new_window_show() {
 }
 
 nedryland_loaded_show() {
+  if [[ "${NEDRYLAND_SKIP_STARTUP_GREETING:-0}" = "1" ]]
+  then
+    return
+  fi
   nedryland_new_window_show
 }
 
@@ -345,5 +349,21 @@ nedryland_reload_show() {
 }
 
 nedryland_show_manual() {
+  nedryland_reload_show
+}
+
+nedryland_resource_and_reload_show() {
+  local previous_skip_startup="${NEDRYLAND_SKIP_STARTUP_GREETING:-0}"
+
+  export NEDRYLAND_SKIP_STARTUP_GREETING=1
+  source ~/.zshrc
+
+  if [[ "$previous_skip_startup" = "1" ]]
+  then
+    export NEDRYLAND_SKIP_STARTUP_GREETING=1
+  else
+    unset NEDRYLAND_SKIP_STARTUP_GREETING
+  fi
+
   nedryland_reload_show
 }

--- a/zshell/zshell.nedryland.zsh
+++ b/zshell/zshell.nedryland.zsh
@@ -2,24 +2,34 @@
 
 nedryland_current_directory=$(dirname "$0")
 
+nedryland_should_animate() {
+  [[ -o interactive ]] && [[ "${NEDRYLAND_ANIMATE:-1}" = "1" ]]
+}
+
+nedryland_message_get() {
+  printf "%s" "$(<"$nedryland_current_directory/../assets/$1")"
+}
+
 nedryland_message_show() {
-  nedryland_ascii_art=$(<"$nedryland_current_directory/../assets/$1")
-  echo "$nedryland_ascii_art\n"
+  printf "%b\n\n" "$(nedryland_message_get "$1")"
 }
 
-nedryland_message_show_large() {
-  nedryland_message_show "nedryland_large.txt"
-}
-
-nedryland_message_show_small() {
-  nedryland_message_show "nedryland_small.txt";
-}
-
-nedryland_message_show_auto() {
+nedryland_terminal_size_get() {
   local terminal_columns="${COLUMNS:-0}"
   local terminal_lines="${LINES:-0}"
-  local large_min_columns="${NEDRYLAND_LARGE_MIN_COLUMNS:-100}"
-  local large_min_lines="${NEDRYLAND_LARGE_MIN_LINES:-14}"
+  local stty_size=""
+  local -a size_parts
+
+  if command -v stty > /dev/null && [[ -t 1 ]]
+  then
+    stty_size="$(stty size <&1 2>/dev/null || true)"
+    if [[ "$stty_size" = <->" "<-> ]]
+    then
+      size_parts=(${=stty_size})
+      terminal_lines="${size_parts[1]}"
+      terminal_columns="${size_parts[2]}"
+    fi
+  fi
 
   if (( terminal_columns <= 0 || terminal_lines <= 0 )) && command -v tput > /dev/null
   then
@@ -27,10 +37,313 @@ nedryland_message_show_auto() {
     terminal_lines="$(tput lines 2>/dev/null || echo 0)"
   fi
 
-  if (( terminal_columns >= large_min_columns && terminal_lines >= large_min_lines ))
+  printf "%s %s" "$terminal_columns" "$terminal_lines"
+}
+
+nedryland_message_asset_auto() {
+  local forced_asset="${NEDRYLAND_FORCE_LOGO_ASSET:-}"
+  local terminal_size
+  local -a terminal_size_parts
+  local terminal_columns=0
+  local terminal_lines=0
+  local large_min_columns="${NEDRYLAND_LARGE_MIN_COLUMNS:-100}"
+  local large_min_lines="${NEDRYLAND_LARGE_MIN_LINES:-14}"
+  local horizontal_padding="${NEDRYLAND_LOGO_HORIZONTAL_PADDING:-2}"
+  local vertical_padding="${NEDRYLAND_LOGO_VERTICAL_PADDING:-1}"
+
+  if [[ -n "$forced_asset" ]]
   then
-    nedryland_message_show_large
-  else
-    nedryland_message_show_small
+    printf "%s" "$forced_asset"
+    return
   fi
+
+  terminal_size="$(nedryland_terminal_size_get)"
+  terminal_size_parts=(${=terminal_size})
+  terminal_columns="${terminal_size_parts[1]:-0}"
+  terminal_lines="${terminal_size_parts[2]:-0}"
+
+  if (( terminal_columns >= large_min_columns + horizontal_padding && terminal_lines >= large_min_lines + vertical_padding ))
+  then
+    printf "nedryland_large.txt"
+  else
+    printf "nedryland_small.txt"
+  fi
+}
+
+nedryland_message_show_large() {
+  nedryland_message_show "nedryland_large.txt"
+}
+
+nedryland_message_show_small() {
+  nedryland_message_show "nedryland_small.txt"
+}
+
+nedryland_message_show_auto() {
+  nedryland_message_show "$(nedryland_message_asset_auto)"
+}
+
+nedryland_random_pick_messages() {
+  local pick_count="${1:-3}"
+  local pool_text="$2"
+  local seed_source
+  local -a pool_messages
+  local -a shuffled_messages
+  local total_messages
+  local i
+  local j
+  local temp_message
+
+  pool_messages=("${(@f)pool_text}")
+  total_messages="${#pool_messages[@]}"
+  if (( total_messages == 0 ))
+  then
+    return
+  fi
+
+  seed_source="$(date +%s%N 2>/dev/null || date +%s)"
+  RANDOM=$(( (seed_source + $$ + RANDOM) % 32768 ))
+
+  if (( pick_count > total_messages ))
+  then
+    pick_count="$total_messages"
+  fi
+
+  shuffled_messages=("${pool_messages[@]}")
+  for (( i = total_messages; i > 1; i-- ))
+  do
+    j=$(( RANDOM % i + 1 ))
+    temp_message="${shuffled_messages[$i]}"
+    shuffled_messages[$i]="${shuffled_messages[$j]}"
+    shuffled_messages[$j]="$temp_message"
+  done
+
+  printf "%s\n" "${(@)shuffled_messages[1,$pick_count]}"
+}
+
+nedryland_new_window_intro_show() {
+  local intro_delay="${NEDRYLAND_INTRO_DELAY:-0.1}"
+  local -a intro_pool=(
+    "> Perimeter fences: ONLINE"
+    "> Tour vehicles: TRACK LOCK CONFIRMED"
+    "> Park systems: READY FOR VISITORS"
+    "> Park command network synchronized"
+    "> Visitor center systems calibrated"
+    "> Electric fence telemetry nominal"
+    "> Tour route tracking active"
+    "> Emergency shutdown relays armed"
+    "> Animal containment monitors stable"
+    "> Access control checkpoints responding"
+    "> Biometric scanners: INITIALIZED"
+    "> Raptor paddock sensors: ACTIVE"
+    "> Helicopter pad beacon: TRANSMITTING"
+    "> Genetics lab environment controls nominal"
+    "> Hammond observation deck: CLEAR"
+  )
+  local -a intro_lines
+  local intro_line
+  local rendered=0
+
+  intro_lines=("${(@f)$(nedryland_random_pick_messages 6 "${(F)intro_pool}")}")
+
+  printf "\033[1;32m"
+  for intro_line in "${intro_lines[@]}"
+  do
+    if (( rendered ))
+    then
+      printf "\033[1A\033[2K"
+    fi
+    printf "%s\n" "$intro_line"
+    rendered=1
+    sleep "$intro_delay"
+  done
+  printf "\033[0m"
+}
+
+nedryland_reboot_intro_show() {
+  local intro_delay="${NEDRYLAND_INTRO_DELAY:-0.1}"
+  local -a reboot_pool=(
+    "> Security systems reboot in progress"
+    "> Door locks and containment controls re-engaging"
+    "> Containment power grid cycling"
+    "> Sector lock matrix restoring"
+    "> Command authorization table reloading"
+    "> Peripheral gate controllers reconnecting"
+    "> Visitor perimeter checkpoints restarting"
+    "> Operations uplink restoring handshake"
+    "> Alarm routing map rebuilding"
+    "> Core security services reinitialized"
+    "> Motion sensor network rebooting"
+    "> Backup generator handoff complete"
+    "> Emergency broadcast system restarting"
+    "> Containment protocol stack reloading"
+    "> Velociraptor enclosure locks cycling"
+  )
+  local -a intro_lines
+  local -a intro_colors=(
+    "\033[1;31m"
+    "\033[1;31m"
+    "\033[1;31m"
+    "\033[1;31m"
+    "\033[1;31m"
+    "\033[1;32m"
+  )
+  local intro_line
+  local intro_index=1
+  local rendered=0
+
+  intro_lines=("${(@f)$(nedryland_random_pick_messages 6 "${(F)reboot_pool}")}")
+
+  for intro_line in "${intro_lines[@]}"
+  do
+    if (( rendered ))
+    then
+      printf "\033[1A\033[2K"
+    fi
+    printf "%b%s%b\n" "${intro_colors[$intro_index]}" "$intro_line" "\033[0m"
+    rendered=1
+    (( intro_index++ ))
+    sleep "$intro_delay"
+  done
+}
+
+nedryland_logo_frame_show_type_on() {
+  local frame_text="$1"
+  local reveal_column="$2"
+  local color_code="$3"
+  local max_width="$4"
+  local preserve_hashes="$5"
+  local -a frame_lines
+  local line_number
+  local line_text
+  local display_line
+  local column_number
+  local character
+
+  frame_lines=("${(@f)frame_text}")
+  for (( line_number = 1; line_number <= ${#frame_lines[@]}; line_number++ ))
+  do
+    line_text="${frame_lines[$line_number]}"
+    display_line=""
+
+    for (( column_number = 1; column_number <= max_width; column_number++ ))
+    do
+      character="${line_text:$(( column_number - 1 )):1}"
+      if [[ -z "$character" ]]
+      then
+        character=" "
+      fi
+
+      if [[ "$character" = " " ]]
+      then
+        display_line+="$character"
+        continue
+      fi
+
+      if [[ "$character" = "#" ]] && (( preserve_hashes ))
+      then
+        display_line+="$character"
+        continue
+      fi
+
+      if (( column_number <= reveal_column ))
+      then
+        display_line+="$character"
+      else
+        display_line+=" "
+      fi
+    done
+
+    printf "%b%s%b\n" "$color_code" "$display_line" "\033[0m"
+  done
+  printf "\n"
+}
+
+nedryland_logo_animate() {
+  local logo_asset="$1"
+  local plain_logo
+  local reveal_delay="${NEDRYLAND_REVEAL_DELAY:-0.002}"
+  local -a logo_lines
+  local line_count
+  local line_text
+  local max_width=0
+  local column_number
+  local reveal_step
+  local preserve_hashes=0
+
+  plain_logo="$(nedryland_message_get "$logo_asset" | sed -E 's/\\033\[[0-9;]*m//g')"
+  logo_lines=("${(@f)plain_logo}")
+  line_count=${#logo_lines[@]}
+  if [[ "$logo_asset" = "nedryland_small.txt" ]] || [[ "$logo_asset" = "nedryland_large.txt" ]]
+  then
+    preserve_hashes=1
+  fi
+
+  for line_text in "${logo_lines[@]}"
+  do
+    if (( ${#line_text} > max_width ))
+    then
+      max_width=${#line_text}
+    fi
+  done
+
+  if (( max_width == 0 ))
+  then
+    nedryland_message_show "$logo_asset"
+    return
+  fi
+
+  printf "\033[?25l"
+
+  for (( reveal_step = 0; reveal_step <= max_width; reveal_step++ ))
+  do
+    if (( reveal_step > 0 ))
+    then
+      printf "\033[%sA" "$(( line_count + 1 ))"
+    fi
+    nedryland_logo_frame_show_type_on "$plain_logo" "$reveal_step" "\033[1;31m" "$max_width" "$preserve_hashes"
+    sleep "$reveal_delay"
+  done
+
+  printf "\033[%sA" "$(( line_count + 1 ))"
+  nedryland_message_show "$logo_asset"
+  printf "\033[?25h"
+}
+
+nedryland_show_with_intro_and_logo() {
+  local intro_function="$1"
+  local logo_asset="$2"
+
+  if nedryland_should_animate && [[ -n "$intro_function" ]]
+  then
+    "$intro_function"
+    nedryland_logo_animate "$logo_asset"
+  else
+    nedryland_message_show "$logo_asset"
+  fi
+}
+
+nedryland_new_window_show() {
+  local logo_asset
+
+  logo_asset="$(nedryland_message_asset_auto)"
+  nedryland_show_with_intro_and_logo "nedryland_new_window_intro_show" "$logo_asset"
+}
+
+nedryland_loaded_show() {
+  nedryland_new_window_show
+}
+
+nedryland_reload_show() {
+  local logo_asset="${NEDRYLAND_RELOAD_LOGO_ASSET:-}"
+
+  if [[ -z "$logo_asset" ]]
+  then
+    logo_asset="$(nedryland_message_asset_auto)"
+  fi
+
+  nedryland_show_with_intro_and_logo "nedryland_reboot_intro_show" "$logo_asset"
+}
+
+nedryland_show_manual() {
+  nedryland_reload_show
 }

--- a/zshell/zshell.nedryland.zsh
+++ b/zshell/zshell.nedryland.zsh
@@ -14,3 +14,23 @@ nedryland_message_show_large() {
 nedryland_message_show_small() {
   nedryland_message_show "nedryland_small.txt";
 }
+
+nedryland_message_show_auto() {
+  local terminal_columns="${COLUMNS:-0}"
+  local terminal_lines="${LINES:-0}"
+  local large_min_columns="${NEDRYLAND_LARGE_MIN_COLUMNS:-100}"
+  local large_min_lines="${NEDRYLAND_LARGE_MIN_LINES:-14}"
+
+  if (( terminal_columns <= 0 || terminal_lines <= 0 )) && command -v tput > /dev/null
+  then
+    terminal_columns="$(tput cols 2>/dev/null || echo 0)"
+    terminal_lines="$(tput lines 2>/dev/null || echo 0)"
+  fi
+
+  if (( terminal_columns >= large_min_columns && terminal_lines >= large_min_lines ))
+  then
+    nedryland_message_show_large
+  else
+    nedryland_message_show_small
+  fi
+}


### PR DESCRIPTION
## What changed

Added four Claude Code skills to the repo and wired their installation into the Nedryland installer:

- **`commit`** — Guides Claude through creating a well-formed commit: stages relevant files, writes a conventional commit message, and handles pre-commit hook failures gracefully.
- **`update-deps`** — Automates dependency updates by bumping packages, running tests, and opening a PR with a generated changelog.
- **`create-pr`** — Opens a pull request for the current branch. Reads any repo PR template and fills out every section with real content from the commits and diff; never leaves placeholders.
- **`curate-commits`** — Reviews the commits on a branch and interactively rewrites them for clarity and consistency before a PR is opened.

The installer (`install.zsh`) now includes an `install_claude_skills` step that symlinks `./claude-skills` into `~/.claude/skills`, making the skills available to Claude Code immediately after setup. The step runs on both initial install and on update.

A `.gitignore` entry for Claude's per-project settings (`.claude/settings.local.json`) was also added to keep machine-local config out of version control.

## Why

Claude Code's slash-command system lets you encode repeatable engineering workflows as skills that live alongside your dotfiles. These four skills cover the most common day-to-day git tasks: committing, updating dependencies, opening PRs, and cleaning up commit history before review. Keeping them in this repo means they travel with the rest of the Nedryland setup and stay in sync across machines.

The `create-pr` skill was extracted into its own file because PR creation logic was previously duplicated inline in `update-deps`. Centralising the logic means template handling and PR conventions only need to change in one place.

## How to verify

1. Run `./install.zsh` on a clean machine (or re-run it on an existing install) and confirm that `~/.claude/skills` is a symlink pointing at `./claude-skills`.
2. Open a Claude Code session in any repo, type `/commit`, `/create-pr`, `/update-deps`, or `/curate-commits`, and confirm each skill loads and follows its documented steps.
3. In a repo with a `.github/pull_request_template.md`, run `/create-pr` and confirm every template section is filled with real content rather than left as a placeholder.